### PR TITLE
Switch False gzip Error to Warning

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Upcoming
+--------
+
+**Bug Fixes**
+
+- Changed log level when a suspected gzipped sitemap can't be un-gzipped from `error` to `warning`, since parsing can usually continue (:pr:`62` by :user:`redreceipt`)
+
 v1.1.0 (2025-01-20)
 -------------------
 

--- a/usp/helpers.py
+++ b/usp/helpers.py
@@ -247,7 +247,7 @@ def ungzipped_response_content(
             data = gunzip(data)
         except GunzipException as ex:
             # In case of an error, just assume that it's one of the non-gzipped sitemaps with ".gz" extension
-            log.warn(
+            log.warning(
                 f"Unable to gunzip response {response}, maybe it's a non-gzipped sitemap: {ex}"
             )
 

--- a/usp/helpers.py
+++ b/usp/helpers.py
@@ -247,7 +247,7 @@ def ungzipped_response_content(
             data = gunzip(data)
         except GunzipException as ex:
             # In case of an error, just assume that it's one of the non-gzipped sitemaps with ".gz" extension
-            log.error(
+            log.warn(
                 f"Unable to gunzip response {response}, maybe it's a non-gzipped sitemap: {ex}"
             )
 


### PR DESCRIPTION
By logging errors, events get sent to analytics captures (like Sentry) that aren't actually a problem since the usp can continue to parse the non-gzipped data