### PR TITLE
Attempt to parse XML sitemaps without namespace set

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Upcoming
+--------
+
+**New Features**
+
+- Support parsing sitemaps when a proper XML namespace is not declared (:pr:`87`)
+
 v1.3.1 (2025-03-31)
 -------------------
 

--- a/docs/reference/formats.rst
+++ b/docs/reference/formats.rst
@@ -92,10 +92,11 @@ Supports the following non-standard features:
 - Truncated files (perhaps because the web server timed out while serving the file) will be parsed as much as possible
 - Any unexpected tags are ignored
 - Timestamps are :ref:`parsed flexibly <xml date>`
+- Sitemaps without an XML namespace will be parsed as if it was there, so long as there is still a root ``<sitemapindex>`` or ``<urlset>`` element.
 
 .. note::
 
-    Namespaces must be declared to parse the sitemap and any extensions correctly. Any unrecognised namespaces will be ignored.
+    Namespaces must be declared to parse extensions correctly. Any unrecognised namespaces will be ignored.
 
 .. _xml sitemap extensions:
 
@@ -150,7 +151,6 @@ The Google Image extension provides additional information to describe images on
 
 If the page contains Google Image data, it is stored as a list of :class:`~usp.objects.page.SitemapImage` objects in :attr:`SitemapPage.images <usp.objects.page.SitemapPage.images>`.
 
-.. _xml date:
 
 Additional Features
 ^^^^^^^^^^^^^^^^^^^
@@ -172,6 +172,8 @@ Alternate Localised Pages
         :language: xml
 
 Alternate localised pages specified with the ``<link>`` tag will be stored as a list in :attr:`SitemapPage.alternates <usp.objects.page.SitemapPage.alternates>`. Language codes are not validated.
+
+.. _xml date:
 
 Date Time Parsing
 ^^^^^^^^^^^^^^^^^
@@ -204,7 +206,7 @@ Implementation details:
 
 - Per the specification, ``<item>`` elements without a ``<title>`` or ``<description>`` are invalid and ignored.
 - Although the specification states ``<link>`` is optional, we ignore an ``<item>`` if it does not contain one
-- Dates are parsed flexibly
+- Dates are :ref:`parsed flexibly <rss date>`
 
 .. note::
 
@@ -244,7 +246,8 @@ Atom 0.3/1.0
 Implementation details:
 
 - The same parser is used for 0.3 and 1.0, and it does not attempt to detect the version, therefore it can accept invalid feeds which are a mixture of both
-- Dates are parsed flexibly
+- Dates are :ref:`parsed flexibly <atom date>`
+- The XML namespace is not required, any XML document with a root element of ``<feed>`` will be parsed as Atom
 
 .. _atom date:
 

--- a/tests/tree/test_edges.py
+++ b/tests/tree/test_edges.py
@@ -1,8 +1,14 @@
 import textwrap
+from decimal import Decimal
 
 from tests.tree.base import TreeTestBase
+from usp.objects.page import SitemapPage, SitemapPageChangeFrequency
 from usp.objects.sitemap import (
+    IndexRobotsTxtSitemap,
+    IndexWebsiteSitemap,
+    IndexXMLSitemap,
     InvalidSitemap,
+    PagesXMLSitemap,
 )
 from usp.tree import sitemap_tree_for_homepage
 
@@ -227,3 +233,91 @@ class TestTreeEdgeCases(TreeTestBase):
         all_pages = list(tree.all_pages())
         assert len(all_pages) == 49
         assert all_pages[-1].url.endswith("page_48.html")
+
+    def test_sitemap_no_ns(self, requests_mock, caplog):
+        requests_mock.add_matcher(TreeTestBase.fallback_to_404_not_found_matcher)
+
+        requests_mock.get(
+            self.TEST_BASE_URL + "/robots.txt",
+            headers={"Content-Type": "text/plain"},
+            text=textwrap.dedent(
+                f"""
+                        User-agent: *
+                        Disallow: /whatever
+
+                        Sitemap: {self.TEST_BASE_URL}/sitemap_index.xml
+                    """
+            ).strip(),
+        )
+
+        requests_mock.get(
+            self.TEST_BASE_URL + "/sitemap_index.xml",
+            headers={"Content-Type": "application/xml"},
+            text=textwrap.dedent(
+                f"""
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <sitemapindex>
+                            <sitemap>
+                                <loc>{self.TEST_BASE_URL}/sitemap_pages.xml</loc>
+                                <lastmod>{self.TEST_DATE_STR_ISO8601}</lastmod>
+                            </sitemap>
+                        </sitemapindex>
+                    """
+            ).strip(),
+        )
+
+        # random_tag is to check assuming sitemap namespace doesn't cause issues
+        requests_mock.get(
+            self.TEST_BASE_URL + "/sitemap_pages.xml",
+            headers={"Content-Type": "application/xml"},
+            text=textwrap.dedent(
+                f"""
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <urlset>
+                            <url>
+                                <loc>{self.TEST_BASE_URL}/about.html</loc>
+                                <lastmod>{self.TEST_DATE_STR_ISO8601}</lastmod>
+                                <changefreq>monthly</changefreq>
+                                <priority>0.8</priority>
+                                <random_tag>random_value</random_tag>
+                            </url>
+                        </urlset>
+                    """
+            ).strip(),
+        )
+
+        expected_sitemap_tree = IndexWebsiteSitemap(
+            url=f"{self.TEST_BASE_URL}/",
+            sub_sitemaps=[
+                IndexRobotsTxtSitemap(
+                    url=f"{self.TEST_BASE_URL}/robots.txt",
+                    sub_sitemaps=[
+                        IndexXMLSitemap(
+                            url=f"{self.TEST_BASE_URL}/sitemap_index.xml",
+                            sub_sitemaps=[
+                                PagesXMLSitemap(
+                                    url=f"{self.TEST_BASE_URL}/sitemap_pages.xml",
+                                    pages=[
+                                        SitemapPage(
+                                            url=f"{self.TEST_BASE_URL}/about.html",
+                                            last_modified=self.TEST_DATE_DATETIME,
+                                            change_frequency=SitemapPageChangeFrequency.MONTHLY,
+                                            priority=Decimal("0.8"),
+                                        )
+                                    ],
+                                )
+                            ],
+                        )
+                    ],
+                )
+            ],
+        )
+
+        actual_sitemap_tree = sitemap_tree_for_homepage(homepage_url=self.TEST_BASE_URL)
+
+        assert expected_sitemap_tree == actual_sitemap_tree
+        assert (
+            'sitemapindex detected without expected xmlns (value is "")' in caplog.text
+        )
+        assert 'urlset detected without expected xmlns (value is "")' in caplog.text
+        assert "Assuming random_tag should be in sitemap namespace" in caplog.text


### PR DESCRIPTION
If a tag which should be the root of an XML sitemap (`urlset` or `sitemapindex`) is encountered without the expected namespace, assume it is an XML sitemap and parse it and its children as if they have the sitemap namespace set.

Fixes #86 