### PR TITLE
Fix gzip warning for transport encoding

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,11 @@ Upcoming
 
 - Support parsing sitemaps when a proper XML namespace is not declared (:pr:`87`)
 
+**Bug Fixes**
+
+- Fix incorrect logic in gunzip behaviour which attempted to gunzip responses that were already gunzipped by requests (:pr:`89`)
+- Change log output for gunzip failures to include the URL instead of request response object (:pr:`89`)
+
 v1.3.1 (2025-03-31)
 -------------------
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -19,3 +19,4 @@ def test_sitemap_parse(site_url, cassette_path):
     for page in sitemap.all_pages():
         page_count += 1
     log.critical(f"Site {site_url} has {page_count} pages")
+    assert page_count > 0

--- a/tests/tree/test_basic.py
+++ b/tests/tree/test_basic.py
@@ -240,8 +240,9 @@ class TestTreeBasic(TreeTestBase):
         requests_mock.get(
             self.TEST_BASE_URL + "/sitemap_4.xml",
             headers={"Content-Type": "application/xml", "Content-Encoding": "gzip"},
-            content=gzip(textwrap.dedent(
-                f"""
+            content=gzip(
+                textwrap.dedent(
+                    f"""
                 <?xml version="1.0" encoding="UTF-8"?>
                 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
                         xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
@@ -258,7 +259,8 @@ class TestTreeBasic(TreeTestBase):
                     </url>
                 </urlset>
             """
-            ).strip()),
+                ).strip()
+            ),
         )
 
         actual_sitemap_tree = sitemap_tree_for_homepage(homepage_url=self.TEST_BASE_URL)
@@ -291,12 +293,20 @@ class TestTreeBasic(TreeTestBase):
         assert len(sitemap_4.pages) == 1
 
         # Check that only sitemap_3 caused a gunzip error
-        assert len([
-            record
-            for record in caplog.records
-            if "Unable to gunzip response" in record.message
-        ]) == 1
-        assert f"Unable to gunzip response for {self.TEST_BASE_URL}/sitemap_3.xml.gz" in caplog.text
+        assert (
+            len(
+                [
+                    record
+                    for record in caplog.records
+                    if "Unable to gunzip response" in record.message
+                ]
+            )
+            == 1
+        )
+        assert (
+            f"Unable to gunzip response for {self.TEST_BASE_URL}/sitemap_3.xml.gz"
+            in caplog.text
+        )
 
     def test_sitemap_tree_for_homepage_huge_sitemap(self, requests_mock):
         """Test sitemap_tree_for_homepage() with a huge sitemap (mostly for profiling)."""

--- a/usp/helpers.py
+++ b/usp/helpers.py
@@ -194,12 +194,10 @@ def __response_is_gzipped_data(
     uri = urlparse(url)
     url_path = unquote_plus(uri.path)
     content_type = response.header("content-type") or ""
-    content_encoding = response.header("content-encoding") or ""
 
     if (
         url_path.lower().endswith(".gz")
         or "gzip" in content_type.lower()
-        or "gzip" in content_encoding.lower()
     ):
         return True
 
@@ -260,7 +258,7 @@ def ungzipped_response_content(
         except GunzipException as ex:
             # In case of an error, just assume that it's one of the non-gzipped sitemaps with ".gz" extension
             log.warning(
-                f"Unable to gunzip response {response}, maybe it's a non-gzipped sitemap: {ex}"
+                f"Unable to gunzip response for {url}, maybe it's a non-gzipped sitemap: {ex}"
             )
 
     # FIXME other encodings

--- a/usp/helpers.py
+++ b/usp/helpers.py
@@ -195,10 +195,7 @@ def __response_is_gzipped_data(
     url_path = unquote_plus(uri.path)
     content_type = response.header("content-type") or ""
 
-    if (
-        url_path.lower().endswith(".gz")
-        or "gzip" in content_type.lower()
-    ):
+    if url_path.lower().endswith(".gz") or "gzip" in content_type.lower():
         return True
 
     else:


### PR DESCRIPTION
Fixes a bug where the gzip encoding detection attempts to gunzip content which was already gunzipped by requests. We still have to manually gunzip sitemaps where the actual file is gzipped (i.e. a `sitemap.xml.gzip` file), but if it's just compressed for transport by the webserver, requests handles it already.