### PR TITLE
Adjust default timeouts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Upcoming
+--------
+
+**Bug Fixes**
+
+- Set different timeouts for HTTP request connection and read to lower maximum request length. Instead of 60s for each, it is now 10s for connection and 60s for read. (:pr:`95`)
+
 v1.4.0 (2025-04-23)
 -------------------
 

--- a/usp/web_client/requests_client.py
+++ b/usp/web_client/requests_client.py
@@ -79,7 +79,7 @@ class RequestsWebClient(AbstractWebClient):
 
     __USER_AGENT = f"ultimate_sitemap_parser/{__version__}"
 
-    __HTTP_REQUEST_TIMEOUT = 60
+    __HTTP_REQUEST_TIMEOUT = (9.05, 60)
     """
     HTTP request timeout.
 
@@ -114,7 +114,7 @@ class RequestsWebClient(AbstractWebClient):
         self.__waiter = RequestWaiter(wait, random_wait)
         self.__session = session or requests.Session()
 
-    def set_timeout(self, timeout: Union[int, Tuple[int, int], None]) -> None:
+    def set_timeout(self, timeout: Optional[Union[float, Tuple[float, float]]]) -> None:
         """Set HTTP request timeout.
 
         See also: `Requests timeout docs <https://requests.readthedocs.io/en/latest/user/advanced/#timeouts>`__


### PR DESCRIPTION
- Set separate connection and read timeouts
- Existing behaviour sets 60 for each implicitly, i.e. 120s total timeout
- Instead set 9.05s for connection (slightly higher than a multiple of 3s as this is the TCP retransmission window) and 60s for read

Closes #92 