### PR TITLE
Fix incorrect Python version being used in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,12 @@ jobs:
         run: pipx install poetry==2.0.1
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: "3.9"
           cache: "poetry"
+      - name: Set Poetry Environment
+        run: poetry env use '${{ steps.setup-python.outputs.python-version }}'
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
       - name: Install Project

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,12 @@ jobs:
         run: pipx install poetry==2.0.1
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: "3.9"
           cache: "poetry"
+      - name: Set Poetry Environment
+        run: poetry env use '${{ steps.setup-python.outputs.python-version }}'
       - name: Install Python dependencies
         run: poetry install --no-interaction --no-root
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,12 @@ jobs:
         run: pipx install poetry==2.0.1
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
+      - name: Set Poetry Environment
+        run: poetry env use '${{ steps.setup-python.outputs.python-version }}'
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
       - name: Install Project

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -19,9 +19,12 @@ jobs:
         run: pipx install poetry==2.0.1
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
+      - name: Set Poetry Environment
+        run: poetry env use '${{ steps.setup-python.outputs.python-version }}'
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
       - name: Install Project


### PR DESCRIPTION
Force `pipx` to use the Python installed by the setup-python action to ensure everything uses the proper Python version